### PR TITLE
Make Transaction#rollback method and expose it

### DIFF
--- a/lib/up_and_at_them/transaction.rb
+++ b/lib/up_and_at_them/transaction.rb
@@ -7,18 +7,22 @@ module UpAndAtThem
 
     def initialize(tasks)
       @tasks = Array(tasks)
+      @finished_tasks = []
       run
     end
 
     def run
-      finished_tasks = []
       @tasks.each do |task|
         task.call
-        finished_tasks << task
+        @finished_tasks << task
       end
     rescue => err
-      finished_tasks.reverse_each(&:rollback)
+      rollback
       raise err
+    end
+
+    def rollback
+      @finished_tasks.reverse_each(&:rollback)
     end
 
   end

--- a/spec/transaction_spec.rb
+++ b/spec/transaction_spec.rb
@@ -42,6 +42,18 @@ describe UpAndAtThem::Transaction do
     end
   end
 
+  describe '#rollback' do
+    it 'forces a rollback each commit in the transaction' do
+      result = [true, true]
+      commit1 = UpAndAtThem::Commit.new { result[0] = false }.on_rollback { result[0] = true }
+      commit2 = UpAndAtThem::Commit.new { result[1] = false }.on_rollback { result[1] = true }
+      transaction = UpAndAtThem::Transaction[commit1, commit2]
+      expect(result).to eq [false, false]
+      transaction.rollback
+      expect(result).to eq [true, true]
+    end
+  end
+
   describe 'duck typed Commits' do
     class TestCommit
       attr_reader :state


### PR DESCRIPTION
This is useful whenever a transaction is nested somehow in another transaction, for example:

``` ruby
class DetermineWinners
  def initialize(game)
    @game = game
  end

  def call
    awards = @game.players.map { |p| AwardPlayer.new(p) }
    @transaction = UpAndAtThem::Transaction.new(awards)
    # do something else...
  end

  def rollback
    @transaction.rollback
    # rollback something else...
  end
end
```

With `#rollback` added, `DetermineWinners` can forcefully rollback it's nested `@transaction` in addition to rolling back it's own actions.
